### PR TITLE
Changed the `headerIcon` field name to `logo`

### DIFF
--- a/siteConfig.yaml
+++ b/siteConfig.yaml
@@ -2,7 +2,7 @@ meta:
   title: Toast API developer portal
   description: The best API documentation ever.
   siteUrl: https://toastintegrations.redoc.ly/
-headerIcon: https://doc.toasttab.com/Ie5QH/assets/images/toast-restaurant-pos.png
+logo: https://doc.toasttab.com/Ie5QH/assets/images/toast-restaurant-pos.png
 enableToc: true
 oasDefinitions:
   # petstore: ./openapi/petstore.yaml
@@ -39,19 +39,4 @@ nav:
   - search: true
 
 footer:
-  copyrightText: Copyright © Redocly 2019-2021. All right reserved.
-  columns:
-    - group: Legal
-      items:
-        - label: Terms of Use
-          href: 'https://redoc.ly/subscription-agreement/'
-        - label: Privacy Notice
-          href: 'https://redoc.ly/privacy-policy/'
-        - label: Cookie Notice
-          href: 'https://redoc.ly/privacy-policy/'
-    - group: Support
-      items:
-        - label: FAQ
-          page: faq.md
-        - label: Contact us
-          page: contact.mdx
+  copyrightText: Copyright © Toast Inc. 2015-2021. All right reserved.


### PR DESCRIPTION
Changed the headerIcon field name to logo. This matches the change in https://github.com/Redocly/developer-portal-starter/pull/97/files.