### PR TITLE
bshultz-toast/DOC-1936

### DIFF
--- a/openapi/toast-labor-api.yaml
+++ b/openapi/toast-labor-api.yaml
@@ -651,7 +651,7 @@ paths:
         type: string
         required: true
     post:
-      summary: Add identifier for active employee
+      summary: Add an identifier for an active employee
       description: Adds an external identifier for an existing employee.
         Include the string value of the new external identifier in the
         message body.<br><br>You cannot change an existing external

--- a/openapi/toast-labor-api.yaml
+++ b/openapi/toast-labor-api.yaml
@@ -12,8 +12,7 @@ info:
     See <cite>Toast API
     Developer's Guide</cite> for more information.
 
-    contact: 
-    email: developer-support@toasttab.com
+    contact: Toast developer support
 schemes:
   - https
 host: toast-api-server

--- a/openapi/toast-labor-api.yaml
+++ b/openapi/toast-labor-api.yaml
@@ -9,7 +9,8 @@ info:
     for your restaurant. The labor API is intended for software engineers, managers, and technical staff who 
     are responsible for integrating third-party systems with the Toast POS system.
 
-    contact: Toast developer support
+    contact: 
+      name: Toast developer support
 schemes:
   - https
 host: toast-api-server

--- a/openapi/toast-labor-api.yaml
+++ b/openapi/toast-labor-api.yaml
@@ -9,8 +9,8 @@ info:
     for your restaurant. The labor API is intended for software engineers, managers, and technical staff who 
     are responsible for integrating third-party systems with the Toast POS system.
 
-    contact: 
-      name: Toast developer support
+  contact: 
+    name: Toast developer support
 schemes:
   - https
 host: toast-api-server

--- a/openapi/toast-labor-api.yaml
+++ b/openapi/toast-labor-api.yaml
@@ -9,9 +9,6 @@ info:
     for your restaurant. The labor API is intended for software engineers, managers, and technical staff who 
     are responsible for integrating third-party systems with the Toast POS system.
 
-    See <cite>Toast API
-    Developer's Guide</cite> for more information.
-
     contact: Toast developer support
 schemes:
   - https
@@ -420,7 +417,7 @@ paths:
       description: Returns an array of
         Employee objects containing
         information about restaurant employees.
-      operationId: employeesInformationGet
+      operationId: employeesGet
       produces:
         - application/json
       parameters:
@@ -495,7 +492,7 @@ paths:
     get:
       summary: Get details on a restaurant employee
       description: Returns an Employee object containing information about one restaurant employee.
-      operationId: employeeInformationGet
+      operationId: employeesEmployeeIdGet
       produces:
         - application/json
       parameters:
@@ -540,7 +537,7 @@ paths:
         using the labor API. Information about deleted employees remains
         available in reports.<br><br>You cannot delete employees who have open
         time entries (time entries that do not have an out date value).
-      operationId: restaurantEmployeeRecordDelete
+      operationId: employeesEmployeeIdDelete
       produces:
         - application/json
       parameters:
@@ -578,7 +575,7 @@ paths:
         Updates the first name, last name, external employee ID, and/or 
         passcode of a restaurant employee. The `PATCH` operation cannot 
         update any other employee information.
-      operationId: restaurantEmployeeInformationPatch
+      operationId: employeesEmployeeIdPatch
       produces:
         - application/json
       parameters:
@@ -660,7 +657,7 @@ paths:
         identifier with another `POST` request; use `PUT` instead. The Toast POS uses this
         external identifier as one of the unique, persistent
         identifiers for an employee record.
-      operationId: externalIdentifierPost
+      operationId: employeesEmployeeIdExternalIdPost
       produces:
         - application/json
       parameters:
@@ -702,7 +699,7 @@ paths:
         identifier for an existing employee might affect reporting and
         other Toast POS functions that select employees using the
         `externalId` value.</em>
-      operationId: externalIdentifierPut
+      operationId: employeesEmployeeIdExternalIdPut
       produces:
         - application/json
       parameters:
@@ -750,7 +747,7 @@ paths:
         group or subgroup level, this operation adds or removes that job for the
         the employee at <em>all restaurant locations</em> in the group or
         subgroup.
-      operationId: jobsListEmployeePut
+      operationId: employeesEmployeeIdJobsPut
       produces:
         - application/json
       parameters:
@@ -807,7 +804,7 @@ paths:
         Specify the wage in U.S. dollars.<br/><br/>You must include all existing
         wage overrides in the message body. Any wage overrides that are not
         present in the array are removed from the employee record.
-      operationId: wageListOverridesForJobsAssignedPut
+      operationId: employeesEmployeeIdWageOverridesPut
       produces:
         - application/json
       parameters:
@@ -852,7 +849,7 @@ paths:
       description: Returns an array of Shift
         objects that contain information about schedule shifts for restaurant
         employees.
-      operationId: scheduleShiftInformationGet
+      operationId: shiftsGet
       produces:
         - application/json
       parameters:
@@ -898,7 +895,7 @@ paths:
     post:
       summary: Create a schedule shift record
       description: Creates a schedule shift record for a restaurant employee.
-      operationId: scheduleShiftRecordPost
+      operationId: shiftsPost
       produces:
         - application/json
       parameters:
@@ -957,7 +954,7 @@ paths:
       description: Returns a Shift object
         containing of information about one schedule shift for a restaurant
         employee.
-      operationId: scheduleShiftInformationGet
+      operationId: shiftsShiftIdGet
       produces:
         - application/json
       parameters:
@@ -989,11 +986,11 @@ paths:
             `requestId` attached to this error that can be referenced by Toast
             support.
     put:
-      summary: Update existing schedule shift record
+      summary: Update an existing schedule shift record
       description: Updates an existing schedule shift record for a
         restaurant employee. A `PUT` request completely replaces the information
         in the existing record.
-      operationId: scheduleShiftRecordPut
+      operationId: shiftsShiftIdPut
       produces:
         - application/json
       parameters:
@@ -1033,11 +1030,11 @@ paths:
         '500':
           description: An unexpected internal error occurred. There is a requestId attached to this error that can be referenced by Toast.
     delete:
-      summary: Delete existing schedule shift record
+      summary: Delete an existing schedule shift record
       description: Marks an existing schedule shift record for a
         restaurant employee as deleted. If the shift record was already deleted, then the operation will succeed (200)
         and no change will be made.
-      operationId: scheduleShiftRecordDelete
+      operationId: shiftsShiftIdDelete
       produces:
         - application/json
       parameters:
@@ -1071,7 +1068,7 @@ paths:
       summary: Get information about employee jobs
       description: Returns an array of Job
         objects containing information about the employee jobs configured at a restaurant.
-      operationId: employeeJobsConfiguredGet
+      operationId: jobsGet
       produces:
         - application/json
       parameters:
@@ -1106,7 +1103,7 @@ paths:
       description: Returns a Job object
         containing information about one employee job at a
         restaurant.
-      operationId: employeeJobInformationGet
+      operationId: jobsJobIdGet
       produces:
         - application/json
       parameters:
@@ -1142,14 +1139,14 @@ paths:
         type: string
         required: true
     post:
-      summary: Add external identifier to existing job
+      summary: Add an external identifier to an existing job
       description: Adds an external identifier for an existing job.
         Include the string value of the new external identifier in the
         message body.<br><br>You cannot change an existing external
         identifier with another `POST` request. The Toast POS uses this
         external identifier as one of the unique, persistent
         identifiers for a job record.
-      operationId: jobExternalIdentifierPost
+      operationId: jobsJobIdExternalIdPost
       produces:
         - application/json
       parameters:
@@ -1191,7 +1188,7 @@ paths:
         identifier for an existing job might affect reporting and other
         Toast POS functions that select jobs using the `externalId`
         value.</em>
-      operationId: jobExternalIdentifierPut
+      operationId: jobsJobIdExternalIdPut
       produces:
         - application/json
       parameters:
@@ -1241,7 +1238,7 @@ paths:
         *  Includes a `businessDate` query parameter to get the time entries with an `inDate` during a specific business date.
 
         Valid requests include one or more `timeEntryId` parameters, both a `startDate` and an `endDate`, both a `modifiedStartDate` and a `modifiedEndDate`, or a `businessDate`.
-      operationId: shiftEventsInformationGet
+      operationId: timeEntriesGet
       produces:
         - application/json
       parameters:
@@ -1301,7 +1298,7 @@ paths:
         object containing information about one employee shift.
         The information includes the shift start time, end time, and the start
         and end times of break periods.
-      operationId: singleShiftEventInformationGet
+      operationId: timeEntriesTimeEntryIdGet
       produces:
         - application/json
       parameters:

--- a/openapi/toast-labor-api.yaml
+++ b/openapi/toast-labor-api.yaml
@@ -4,22 +4,19 @@ info:
   version: 1.9.0
   title: Toast Labor API
   description: |
-    ## Overview
 
-    This document provides information about the Toast labor API. The labor API
-    is a set of REST web services that you can use to manage the employees,
-    jobs, and shifts for your restaurant. The labor API is intended for software
-    engineers, managers, and technical staff who are responsible for integrating
-    third-party systems with the Toast POS system.
+    Toast labor API is a set of REST web services that you can use to manage the employees, jobs, and shifts 
+    for your restaurant. The labor API is intended for software engineers, managers, and technical staff who 
+    are responsible for integrating third-party systems with the Toast POS system.
 
-    See general information about using Toast REST APIs in the <cite>Toast API
-    Developer's Guide</cite>.
+    See <cite>Toast API
+    Developer's Guide</cite> for more information.
 
-    contact:
-    name: Toast API Support
+    contact: 
     email: developer-support@toasttab.com
 schemes:
   - https
+host: toast-api-server
 basePath: /labor/v1
 consumes:
   - application/json
@@ -420,11 +417,11 @@ definitions:
 paths:
   /employees:
     get:
-      summary: Get details on restaurant employees.
+      summary: Get details on restaurant employees
       description: Returns an array of
-        <a href="#/definitions/Employee">Employee</a> objects containing
+        Employee objects containing
         information about restaurant employees.
-      operationId: employeesGetInformation
+      operationId: employeesInformationGet
       produces:
         - application/json
       parameters:
@@ -476,7 +473,7 @@ paths:
           format: string
           required: true
         - name: body
-          description: An <a href="#/definitions/Employee">Employee</a> object
+          description: An Employee object
             containing information about the employee, including the employee's
             name and email address. 
           in: body
@@ -497,9 +494,9 @@ paths:
           description: An unexpected internal error occurred. There is a requestId attached to this error that can be referenced by Toast.
   /employees/{employeeId}:
     get:
-      summary: Get details on a restaurant employee.
-      description: Returns an <a href="#/definitions/Employee">Employee</a> object containing information about one restaurant employee.
-      operationId: employeeGetInformation
+      summary: Get details on a restaurant employee
+      description: Returns an Employee object containing information about one restaurant employee.
+      operationId: employeeInformationGet
       produces:
         - application/json
       parameters:
@@ -528,7 +525,7 @@ paths:
         '500':
           description: An unexpected internal error occurred. There is a requestId attached to this error that can be referenced by Toast.
     delete:
-      summary: Deletes a restaurant employee record.
+      summary: Delete a restaurant employee record
       description: Deletes a restaurant employee record by marking it as
         deleted. A deleted employee cannot log in at the restaurant or open new
         time entries.<br><br>If you `GET` an employee record that has been deleted, its
@@ -563,7 +560,7 @@ paths:
       responses:
         '200':
           description: The employee has been deleted. Returns an
-            <a href="#/definitions/Employee">Employee</a> object containing
+            Employee object containing
             information about the deleted restaurant employee.
           schema:
             $ref: '#/definitions/Employee'
@@ -577,7 +574,7 @@ paths:
             can use the `requestId` in the error message to help troubleshoot the
             problem.
     patch:
-      summary: Updates restaurant employee information.
+      summary: Update restaurant employee information
       description: |
         Updates the first name, last name, external employee ID, and/or 
         passcode of a restaurant employee. The `PATCH` operation cannot 
@@ -657,7 +654,7 @@ paths:
         type: string
         required: true
     post:
-      summary: Adds identifier for active employee.
+      summary: Add identifier for active employee
       description: Adds an external identifier for an existing employee.
         Include the string value of the new external identifier in the
         message body.<br><br>You cannot change an existing external
@@ -697,7 +694,7 @@ paths:
           schema:
             $ref: '#/definitions/Employee'
     put:
-      summary: Adds/replaces identifier for employee.
+      summary: Add or replace identifier for employee
       description: Adds or replaces the external identifier for an
         existing employee. Include the string value of the new external
         identifier in the message body.<br><br>The Toast POS uses this
@@ -747,7 +744,7 @@ paths:
         type: string
         required: true
     put:
-      summary: Replaces the jobs list for an employee.
+      summary: Replace the jobs list for an employee
       description:
         Replaces the list of jobs for an employee. Include a JSON  array of job
         identifiers in the message body. <br/><br/>If a job is defined at the restaurant
@@ -803,7 +800,7 @@ paths:
         type: string
         required: true
     put:
-      summary: Replaces the list of wage overrides.
+      summary: Replace the list of wage overrides
       description: Replaces the list of wage overrides for the jobs that are
         assigned to an employee. Include a JSON  array of <a
         href="#/definitions/JobWageOverride">JobWageOverride</a> objects in the
@@ -852,8 +849,8 @@ paths:
             $ref: '#/definitions/Employee'
   /shifts:
     get:
-      summary: Get schedule shifts for employees.
-      description: Returns an array of <a href="#/definitions/Shift">Shift</a>
+      summary: Get schedule shifts for employees
+      description: Returns an array of Shift
         objects that contain information about schedule shifts for restaurant
         employees.
       operationId: scheduleShiftInformationGet
@@ -900,7 +897,7 @@ paths:
         '500':
           description: An unexpected internal error occurred. There is a requestId attached to this error that can be referenced by Toast.
     post:
-      summary: Creates a schedule shift record.
+      summary: Create a schedule shift record
       description: Creates a schedule shift record for a restaurant employee.
       operationId: scheduleShiftRecordPost
       produces:
@@ -921,7 +918,7 @@ paths:
           format: string
           required: true
         - name: body
-          description: A <a href="#/definitions/Shift">Shift</a> object
+          description: A Shift object
             containing information about the shift, including the job
             identifier, the employee identifier, and the start and end times.
           in: body
@@ -957,8 +954,8 @@ paths:
           description: An unexpected internal error occurred. There is a requestId attached to this error that can be referenced by Toast.
   /shifts/{shiftId}:
     get:
-      summary: Get information on a schedule shift.
-      description: Returns a <a href="#/definitions/Shift">Shift</a> object
+      summary: Get information on a schedule shift
+      description: Returns a Shift object
         containing of information about one schedule shift for a restaurant
         employee.
       operationId: scheduleShiftInformationGet
@@ -993,7 +990,7 @@ paths:
             `requestId` attached to this error that can be referenced by Toast
             support.
     put:
-      summary: Updates existing schedule shift record.
+      summary: Update existing schedule shift record
       description: Updates an existing schedule shift record for a
         restaurant employee. A `PUT` request completely replaces the information
         in the existing record.
@@ -1037,7 +1034,7 @@ paths:
         '500':
           description: An unexpected internal error occurred. There is a requestId attached to this error that can be referenced by Toast.
     delete:
-      summary: Deletes existing schedule shift record.
+      summary: Delete existing schedule shift record
       description: Marks an existing schedule shift record for a
         restaurant employee as deleted. If the shift record was already deleted, then the operation will succeed (200)
         and no change will be made.
@@ -1072,8 +1069,8 @@ paths:
           description: An unexpected internal error occurred. There is a requestId attached to this error that can be referenced by Toast.
   /jobs:
     get:
-      summary: Get information about employee jobs.
-      description: Returns an array of <a href="#/definitions/Job">Job</a>
+      summary: Get information about employee jobs
+      description: Returns an array of Job
         objects containing information about the employee jobs configured at a restaurant.
       operationId: employeeJobsConfiguredGet
       produces:
@@ -1106,8 +1103,8 @@ paths:
           description: An unexpected internal error occurred. There is a requestId attached to this error that can be referenced by Toast.
   /jobs/{jobId}:
     get:
-      summary: Get information about one employee job.
-      description: Returns a <a href="#/definitions/Job">Job</a> object
+      summary: Get information about one employee job
+      description: Returns a Job object
         containing information about one employee job at a
         restaurant.
       operationId: employeeJobInformationGet
@@ -1146,7 +1143,7 @@ paths:
         type: string
         required: true
     post:
-      summary: Adds external identifier to existing job.
+      summary: Add external identifier to existing job
       description: Adds an external identifier for an existing job.
         Include the string value of the new external identifier in the
         message body.<br><br>You cannot change an existing external
@@ -1186,7 +1183,7 @@ paths:
           schema:
             $ref: '#/definitions/Job'
     put:
-      summary: Adds/replaces a job's external identifier.
+      summary: Add/replace a job's external identifier
       description: Adds or replaces the external identifier for an
         existing job. Include the string value of the new external
         identifier in the message body. <br><br>The Toast POS uses this
@@ -1229,10 +1226,10 @@ paths:
             $ref: '#/definitions/Job'
   /timeEntries:
     get:
-      summary: Get information about shift events.
+      summary: Get information about shift events
       description: |
         Returns an array of
-        <a href="#/definitions/TimeEntry">TimeEntry</a> objects that contain
+        TimeEntry objects that contain
         information about employee shift events. The information includes shift
         start times, end times, and the start and end times of break periods.
 
@@ -1300,8 +1297,8 @@ paths:
           description: An unexpected internal error occurred. There is a requestId attached to this error that can be referenced by Toast.
   /timeEntries/{timeEntryId}:
     get:
-      summary: Get information about one shift's events.
-      description: Returns an <a href="#/definitions/TimeEntry">TimeEntry</a>
+      summary: Get information about one shift's events
+      description: Returns an TimeEntry
         object containing information about one employee shift.
         The information includes the shift start time, end time, and the start
         and end times of break periods.


### PR DESCRIPTION
Labor API updates:
-added `host: toast-api-server` to top level of spec
-updated some summaries adhering to API Style Guide (imperative tone, period deletion)
-removed the name field from the contact section
-condensed top-level description and deleted the `## Overview` markdown
-fixed erroneous syntax on an `operationId` or two
-stripped the HTML links from Objects